### PR TITLE
add openhouse 2025 to news

### DIFF
--- a/content/en/news/openhouse2025.md
+++ b/content/en/news/openhouse2025.md
@@ -11,7 +11,7 @@ We are pleased to announce the 2025 OpenMS Open House.<br>
 **Format: Drop-in session — come by anytime, stay as long or as little as you’d like**! <br>
 
 This event offers a great opportunity to:
-- Discuss **computational mass spectrometry** and its application
+- Discuss **computational mass spectrometry** and its applications
 - Learn more about **open-source software development**
 - Explore posters on selected topics including pyOpenMS, pyOpenMS_viz, OpenMS WebApps, Library Free DIA with OpenSWATH and DIAWeaver
 - **Bring your own data** for discussion and feedback


### PR DESCRIPTION
Add openhouse 2025 to news section 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a news article announcing the 2025 OpenMS Open House in Toronto. Specifies event date, time and location; meeting format; discussion topics (computational mass spectrometry, open‑source software development); poster opportunities for OpenMS-related work; a note on timing relative to HUPO; and a registration link for participants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->