### PR TITLE
remove gitter; add external apps

### DIFF
--- a/content/en/applications/_index.md
+++ b/content/en/applications/_index.md
@@ -7,6 +7,13 @@ shortcutDepth: 2
 
 OpenMS is a flexible codebase that can be tailored to many different applications ranging from the standard label free analysis to top down, metabolomics, crosslinking or DIA.
 
-Choose an application of OpenMS that you are interested in. The pages will provide explanations on how OpenMS can be used to solve your problems and link to workflows that allow you to apply the tools to your data.
+OpenMS is used in a variety of applications: popular third-party apps which run OpenMS under the hood include
 
-If you cannot find your application in the menu on the left, more OpenMS tools can be found in the [TOPP documentation](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/nightly/html/TOPP_documentation.html).
+ - QuantMS [https://quantms.org](https://quantms.org)
+ - QCCloud2 [https://qcloud2.crg.eu](https://qcloud2.crg.eu)
+ - Proteome Discoverer Community Nodes
+ 
+
+Applications which are integrated into OpenMS releases or are available as pipelines (e.g. using KNIME or Nextflow) are listed below. The pages will provide explanations on how OpenMS can be used to solve your problems and link to workflows that allow you to apply the tools to your data.
+
+If you cannot find your application in the menu on the left, more OpenMS tools can be found in the [TOPP documentation](https://openms.de/doxygen/nightly/html/TOPP_documentation.html).

--- a/content/en/applications/nase.md
+++ b/content/en/applications/nase.md
@@ -4,14 +4,14 @@ subtitle: Nucleic acid search engine
 sidebar: false
 ---
 
-NASE is now included in OpenMS release, 2.5.
+NASE is now included in OpenMS release, 2.5 or later.
 
 Requirements:
 
 - HCD (or ETD) data of RNA oligonucleotides acquired on a high-resolution mass spectrometer
 - Fragment spectra (MS/MS) need to be centroided (either on acquisition, conversion, or in a workflow using the TOPP tool PeakPickerHiRes)
 - Developed and tested on Linux (Ubuntu 18.04 and 18.10) systems with data from orbitrap instruments
-- Operating system: OpenMS installers have been tested on Ubuntu Linux 18.04, Windows 7/8/10, and macOS 10.12-10.14. If you experience any troubles don’t hesitate to contact the OpenMS team on Gitter [chat](https://gitter.im/OpenMS/OpenMS) or open an issue in the OpenMS [GitHub repository](https://github.com/OpenMS/OpenMS/issues).
+- Operating system: OpenMS installers have been tested on Ubuntu Linux 18.04, Windows 7/8/10, and macOS 10.12-10.14. If you experience any troubles don’t hesitate to contact the OpenMS team or open an issue in the OpenMS [GitHub repository](https://github.com/OpenMS/OpenMS/issues).
 
 ### Publication:
 

--- a/content/en/communication.md
+++ b/content/en/communication.md
@@ -13,7 +13,7 @@ Here's how to get started:
 
 - 📚 Browse through the main library code under [OpenMS/OpenMS](https://github.com/openms/openms/issues)
 - 👩‍💻 Check out the [documentation](https://openms.readthedocs.io/en/latest/index.html).
-- 🙋‍♀️ Come and say hi on our [![Discord Shield](https://img.shields.io/discord/832282841836159006?style=flat-square&message=Discord&color=5865F2&logo=Discord&logoColor=FFFFFF&label=Discord)](https://discord.gg/4TAGhqJ7s5) or [![Gitter](https://img.shields.io/static/v1?style=flat-square&message=on%20Gitter&color=ED1965&logo=Gitter&logoColor=FFFFFF&label=Chat)](https://gitter.im/OpenMS/OpenMS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) channels.
+- 🙋‍♀️ Come and say hi on our [![Discord Shield](https://img.shields.io/discord/832282841836159006?style=flat-square&message=Discord&color=5865F2&logo=Discord&logoColor=FFFFFF&label=Discord)](https://discord.gg/4TAGhqJ7s5) channel.
 - 🍿 Tune in for news about developer/user meetings and events, [get involved]({{< ref "news.md" >}})!
 - 🌈 Please abide by our [community code of conduct](https://github.com/OpenMS/OpenMS/blob/develop/CODE_OF_CONDUCT.md)
 
@@ -55,12 +55,6 @@ Documentation
 
 ***
 
-### <a class="button cta rounded primary-btn raised" href="https://gitter.im/OpenMS/OpenMS">Gitter</a>
-
-A real-time chat room to ask questions about OpenMS.
-
-***
-
 ### <a class="button cta rounded primary-btn raised" href="https://sourceforge.net/p/open-ms/mailman/open-ms-announcements">OpenMS mailing list</a>
 
 
@@ -70,11 +64,6 @@ There are two mailing list currently:
 - [open-ms-announcements](https://sourceforge.net/p/open-ms/mailman/open-ms-announcements/) - Announcements about OpenMS, such as for releases, developer meetings, sprints or conference talks are made on this list.
 - [open-ms-general](https://sourceforge.net/p/open-ms/mailman/open-ms-general/) - For addressing any queries or suggestion from the users.
 
-***
-
-### <a class="button cta rounded primary-btn raised" href="https://twitter.com/openmsteam">Twitter</a> 
-
-Contact us or just follow the latest OpenMS news on Twitter.
 
 ***
 

--- a/content/en/contribute.md
+++ b/content/en/contribute.md
@@ -15,7 +15,7 @@ list](https://lists.sourceforge.net/lists/listinfo/open-ms-general/) or
 issue).
 
 Those are our preferred channels (open source is open by nature), but
-if you prefer to talk privately, contact our community coordinators at [Gitter](https://gitter.im/OpenMS/OpenMS).
+if you prefer to talk privately, contact our community coordinators on the [OpenMS Discord Server](https://discord.gg/aJyWqf6uCn).
 
 If you only want to be informed of new versions of OpenMS, please subscribe to the mailing list [open-ms-announcements](https://lists.sourceforge.net/lists/listinfo/open-ms-announcements).
 

--- a/content/en/help.md
+++ b/content/en/help.md
@@ -5,8 +5,7 @@ sidebar: false
 
 **User questions:** The best way to get help is to post your question to a site
 like [StackOverflow](https://stackoverflow.com/search?q=openms), with
-thousands of users available to answer.  Smaller alternatives include
-[Gitter](https://gitter.im/openms/openms). We wish we could keep an eye on
+thousands of users available to answer. We wish we could keep an eye on
 these sites, or answer questions directly, but the volume is just a little
 overwhelming!
 
@@ -31,12 +30,6 @@ is available [here](https://lists.sourceforge.net/lists/listinfo/open-ms-general
 - For bug reports;
 - documentation issues (e.g. "I found this section unclear");
 - and feature requests (e.g. "I would like to have a new interpolation method in `spectrum.sortByPosition()`").
-
-***
-
-### [Gitter](https://gitter.im/openms/openms)
-
-A real-time chat room where users and community members help each other.
 
 ***
 

--- a/content/en/report-handling-manual.md
+++ b/content/en/report-handling-manual.md
@@ -81,7 +81,7 @@ Possible responses may include:
 * A public reprimand. In this case, the Committee chair will deliver that reprimand in the same venue that the violation occurred, within the limits of practicality. E.g., the original mailing list for an email violation, but for a chat room discussion where the person/context may be gone, they can be reached by other means. The group may choose to publish this message elsewhere for documentation purposes.
 * A request for a public or private apology, assuming the reporter agrees to this idea: they may at their discretion refuse further contact with the violator. The chair will deliver this request. The Committee may, if it chooses, attach “strings” to this request: for example, the group may ask a violator to apologize in order to retain one’s membership on a mailing list.
 * A “mutually agreed upon hiatus” where the Committee asks the individual to temporarily refrain from community participation. If the individual chooses not to take a temporary break voluntarily, the Committee may issue a “mandatory cooling off period”.
-* A permanent or temporary ban from some or all OpenMS spaces (mailing lists, gitter.im, etc.). The group will maintain records of all such bans so that they may be reviewed in the future or otherwise maintained.
+* A permanent or temporary ban from some or all OpenMS spaces (mailing lists, Discord, etc.). The group will maintain records of all such bans so that they may be reviewed in the future or otherwise maintained.
 
 Once a resolution is agreed upon, but before it is enacted, the Committee will contact the original reporter and any other affected parties and explain the proposed resolution. The Committee will ask if this resolution is acceptable, and must note feedback for the record.
 


### PR DESCRIPTION

#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized Applications page: added a curated list of popular third-party apps (QuantMS, QCCloud2, Proteome Discoverer Community Nodes) with links, clarified which apps are bundled or available as pipelines, moved explanatory workflow content, and updated the TOPP docs link; clarified NASE release wording to "2.5 or later" and updated contact guidance.

* **Communication**
  * Consolidated community channels to Discord, removing Gitter and Twitter references and updating support/moderation links across docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->