### PR TITLE
Add Helsinki workshop announcement for April 30th 2026

### DIFF
--- a/content/en/news/helsinki_workshop_2026.md
+++ b/content/en/news/helsinki_workshop_2026.md
@@ -1,0 +1,33 @@
+---
+title: MS analysis with OpenMS and OpenDIAKiosk workshop in Helsinki on April 30th 2026.
+authors: ["Sam Wein"]
+date: 2026-04-24
+summary: We are teaching a one-day workshop on MS analysis with OpenMS and OpenDIAKiosk at the University of Helsinki on April 30th 2026. Click the header above for more information.
+---
+
+The OpenMS team will teach a one-day workshop on mass spectrometry analysis with OpenMS and OpenDIAKiosk at the University of Helsinki.
+<br><br>
+Topic: **MS analysis with OpenMS and OpenDIAKiosk**
+<br>
+**Educators:** Sam Wein and Tom Müller, OpenMS Inc., and University of Tübingen, Germany
+<br>
+**Date:** April 30th, 9:00-17:00
+<br>
+**Location:** Sali 3, Biomedicum 1, Meilahti Campus, University of Helsinki
+<br><br>
+**Contents:**
+<br>
+This course provides a comprehensive overview of key technologies in mass spectrometry-based proteomics, offering a balanced mix of theoretical lectures and hands-on exercises. Core topics include an introduction to liquid chromatography-tandem mass spectrometry (LC-MS/MS), data-dependent acquisition (DDA), data-independent acquisition (DIA), as well as strategies for accurate protein identification and quantitation.
+<br><br>
+**Learning goals:**
+<br>
+Participants will improve their theoretical understanding of mass spectrometry as well as their skills at using OpenMS and other bioinformatics resources to analyze data.
+<br><br>
+**Prerequisites:**
+<br>
+Participants should bring laptops to be able to carry out this training on their own computers.
+<br><br>
+**Keywords:** Proteomics, Mass spectrometry, Bioinformatics, LC-MS/MS, Data Independent Acquisition
+<br><br>
+**Contact:** Sam Wein: sam@openms.de
+<br><br>

--- a/content/en/news/helsinki_workshop_2026.md
+++ b/content/en/news/helsinki_workshop_2026.md
@@ -7,7 +7,7 @@ summary: We are teaching a one-day workshop on MS analysis with OpenMS and OpenD
 
 The OpenMS team will teach a one-day workshop on mass spectrometry analysis with OpenMS and OpenDIAKiosk at the University of Helsinki.
 <br><br>
-Topic: **MS analysis with OpenMS and OpenDIAKiosk**
+**Topic:** MS analysis with OpenMS and OpenDIAKiosk
 <br>
 **Educators:** Sam Wein and Tom David Müller
 <br>

--- a/content/en/news/helsinki_workshop_2026.md
+++ b/content/en/news/helsinki_workshop_2026.md
@@ -1,6 +1,6 @@
 ---
 title: MS analysis with OpenMS and OpenDIAKiosk workshop in Helsinki on April 30th 2026.
-authors: ["Sam Wein"]
+authors: ["Tom David Müller"]
 date: 2026-04-24
 summary: We are teaching a one-day workshop on MS analysis with OpenMS and OpenDIAKiosk at the University of Helsinki on April 30th 2026. Click the header above for more information.
 ---
@@ -9,7 +9,7 @@ The OpenMS team will teach a one-day workshop on mass spectrometry analysis with
 <br><br>
 Topic: **MS analysis with OpenMS and OpenDIAKiosk**
 <br>
-**Educators:** Sam Wein and Tom Müller, OpenMS Inc., and University of Tübingen, Germany
+**Educators:** Sam Wein and Tom David Müller
 <br>
 **Date:** April 30th, 9:00-17:00
 <br>

--- a/content/en/news/helsinki_workshop_2026.md
+++ b/content/en/news/helsinki_workshop_2026.md
@@ -1,5 +1,5 @@
 ---
-title: MS analysis with OpenMS and OpenDIAKiosk workshop in Helsinki on April 30th 2026.
+title: Workshop at University of Helsinki on April 30th 2026.
 authors: ["Tom David Müller"]
 date: 2026-04-24
 summary: We are teaching a one-day workshop on MS analysis with OpenMS and OpenDIAKiosk at the University of Helsinki on April 30th 2026. Click the header above for more information.


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Adds a news article announcing the MS analysis workshop with OpenMS and OpenDIAKiosk at the University of Helsinki on April 30th, 2026.

This new content page includes:
- Workshop title, date, and location details
- Educator information (Sam Wein and Tom David Müller)
- Course contents covering LC-MS/MS, DDA, and DIA technologies
- Learning goals for participants
- Prerequisites and contact information

https://claude.ai/code/session_015uqRwjE11iSmtJwusJ35np

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added news entry for a mass spectrometry analysis workshop in Helsinki scheduled for 2026, including event details, learning objectives, curriculum topics (LC-MS/MS analysis, DDA/DIA modes, protein identification and quantitation), prerequisites, and contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->