### PR TITLE
Add redirects and config for OpenDDA and OpenDIA webapps

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,22 +102,30 @@ languages:
           logo: /images/webapp/logo/umetaflow.png
           description: This app offers the powerful UmetaFlow pipeline for untargeted metabolomics in an accessible user interface.
         - index: 2
+          url: https://opendia.webapps.openms.org/
+          logo: /images/webapp/logo/OpenDIAKiosk_logo_portrait.svg
+          description: OpenDIA is an interactive web app for teaching Data-Independent Acquisition (DIA) concepts and running practical DIA analysis tools.
+        - index: 3
+          url: https://opendda.webapps.openms.org/
+          logo: /images/webapp/logo/openDDA.svg
+          description: OpenDDA is a browser-based tool to identify and quantify proteins from mass spectrometry data, with built-in volcano plots, PCA, and heatmaps — no command line required.
+        - index: 4
           url: https://abi-services.cs.uni-tuebingen.de/nuxl/
           logo: /images/webapp/logo/nuxl.png
           description: NuXL is a dedicated software package designed for the analysis of XL-MS (cross-linking mass spectrometry).
-        - index: 3
+        - index: 5
           url: https://abi-services.cs.uni-tuebingen.de/mhcquant/
           logo: /images/webapp/logo/mhcquant.svg
           description: MHCQuant is a web application for analysis of MHC-bound peptides in immunopeptidomics studies.
-        - index: 4
+        - index: 6
           url: https://abi-services.cs.uni-tuebingen.de/toppview-lite/
           logo: /images/webapp/logo/toppview-lite.svg
           description: TOPPView Lite is a web-based viewer for interactive visualization and exploration of mass spectrometry data.
-        - index: 5
+        - index: 7
           logo: /images/webapp/logo/naseweis.png
           url: https://abi-services.cs.uni-tuebingen.de/naseweis/
           description: NASEWEIS is a WebApp for the NucleicAcidSearch Engine. It allows for library searching of Oligonucleotides.
-        - index: 6
+        - index: 8
           url: https://abi-services.cs.uni-tuebingen.de/streamsage/
           logo: /images/webapp/logo/streamsage.png
           description: StreamSage is a web application for performing proteomics database searching in your browser.

--- a/config.yaml
+++ b/config.yaml
@@ -102,11 +102,11 @@ languages:
           logo: /images/webapp/logo/umetaflow.png
           description: This app offers the powerful UmetaFlow pipeline for untargeted metabolomics in an accessible           url: https://opendia.webapps.openms.org/
           logo: /images/webapp/logo/OpenDIAKiosk_logo_portrait.svg
-          description: OpenDIA is an interactive web app for teaching Data-Independent Acquisition (DIA) concepts and running practical DIA analysis tools.
+          description: OpenDIA is an interactive web app for Data-Independent Acquisition (DIA) analysis.
         - index: 3
           url: https://opendda.webapps.openms.org/
           logo: /images/webapp/logo/openDDA.svg
-          description: OpenDDA is a browser-based tool to identify and quantify proteins from mass spectrometry data, with built-in volcano plots, PCA, and heatmaps — no command line required.
+          description: OpenDDA is a browser-based tool to identify and quantify proteins from DDA mass spectrometry data..
         - index: 4
           url: https://abi-services.cs.uni-tuebingen.de/nuxl/
           logo: /images/webapp/logo/nuxl.png

--- a/config.yaml
+++ b/config.yaml
@@ -100,9 +100,7 @@ languages:
         - index: 1
           url: https://abi-services.cs.uni-tuebingen.de/umetaflow/
           logo: /images/webapp/logo/umetaflow.png
-          description: This app offers the powerful UmetaFlow pipeline for untargeted metabolomics in an accessible user interface.
-        - index: 2
-          url: https://opendia.webapps.openms.org/
+          description: This app offers the powerful UmetaFlow pipeline for untargeted metabolomics in an accessible           url: https://opendia.webapps.openms.org/
           logo: /images/webapp/logo/OpenDIAKiosk_logo_portrait.svg
           description: OpenDIA is an interactive web app for teaching Data-Independent Acquisition (DIA) concepts and running practical DIA analysis tools.
         - index: 3

--- a/static/_redirects
+++ b/static/_redirects
@@ -127,6 +127,36 @@ https://cdash.openms.de/* https://cdash.seqan.de/:splat 301!
 
 /webapps/toolbox https://abi-services.cs.uni-tuebingen.de/peakstorm/ 301
 
+/OpenDDA https://opendda.webapps.openms.org/ 301
+/Opendda https://opendda.webapps.openms.org/ 301
+/opendda https://opendda.webapps.openms.org/ 301
+/OPENDDA https://opendda.webapps.openms.org/ 301
+/open-dda https://opendda.webapps.openms.org/ 301
+/Open-DDA https://opendda.webapps.openms.org/ 301
+
+/quantms-web https://opendda.webapps.openms.org/ 301
+/quantmsweb https://opendda.webapps.openms.org/ 301
+/QuantMS-Web https://opendda.webapps.openms.org/ 301
+/QuantMSWeb https://opendda.webapps.openms.org/ 301
+/quantms https://opendda.webapps.openms.org/ 301
+/QuantMS https://opendda.webapps.openms.org/ 301
+/QUANTMS https://opendda.webapps.openms.org/ 301
+
+/OpenDIA https://opendia.webapps.openms.org/ 301
+/Opendia https://opendia.webapps.openms.org/ 301
+/opendia https://opendia.webapps.openms.org/ 301
+/OPENDIA https://opendia.webapps.openms.org/ 301
+/open-dia https://opendia.webapps.openms.org/ 301
+/Open-DIA https://opendia.webapps.openms.org/ 301
+/OpenDIAKiosk https://opendia.webapps.openms.org/ 301
+/opendiakiosk https://opendia.webapps.openms.org/ 301
+/OPENDIAKIOSK https://opendia.webapps.openms.org/ 301
+
+/webapps/quantms-web https://opendda.webapps.openms.org/ 301
+/webapps/opendda https://opendda.webapps.openms.org/ 301
+/webapps/opendia https://opendia.webapps.openms.org/ 301
+/webapps/opendiakiosk https://opendia.webapps.openms.org/ 301
+
 # Redirects for WebApps
 /webapps/* https://abi-services.cs.uni-tuebingen.de/:splat 301
 
@@ -137,5 +167,5 @@ https://cdash.openms.de/* https://cdash.seqan.de/:splat 301!
 /workshops/quantification https://colab.research.google.com/github/t0mdavid-m/Notebooks-ZA2026/blob/master/Quantification.ipynb
 /workshops/roadshow/fragments http://abi-services.cs.uni-tuebingen.de/toppview-lite/?workspace=workshop
 /workshops/roadshow/umetaflow http://abi-services.cs.uni-tuebingen.de/umetaflow/?workspace=workshop
-/workshops/roadshow/quantms http://abi-services.cs.uni-tuebingen.de/quantms-web/?workspace=workshop
+/workshops/roadshow/quantms https://opendda.webapps.openms.org/?workspace=workshop
 /workshops/upss26 https://colab.research.google.com/github/t0mdavid-m/Notebooks-ZA2026/blob/master/PeptideSearch.ipynb

--- a/static/_redirects
+++ b/static/_redirects
@@ -127,35 +127,35 @@ https://cdash.openms.de/* https://cdash.seqan.de/:splat 301!
 
 /webapps/toolbox https://abi-services.cs.uni-tuebingen.de/peakstorm/ 301
 
-/OpenDDA https://opendda.webapps.openms.org/ 301
-/Opendda https://opendda.webapps.openms.org/ 301
-/opendda https://opendda.webapps.openms.org/ 301
-/OPENDDA https://opendda.webapps.openms.org/ 301
-/open-dda https://opendda.webapps.openms.org/ 301
-/Open-DDA https://opendda.webapps.openms.org/ 301
+/OpenDDA http://opendda.webapps.openms.org/ 301
+/Opendda http://opendda.webapps.openms.org/ 301
+/opendda http://opendda.webapps.openms.org/ 301
+/OPENDDA http://opendda.webapps.openms.org/ 301
+/open-dda http://opendda.webapps.openms.org/ 301
+/Open-DDA http://opendda.webapps.openms.org/ 301
 
-/quantms-web https://opendda.webapps.openms.org/ 301
-/quantmsweb https://opendda.webapps.openms.org/ 301
-/QuantMS-Web https://opendda.webapps.openms.org/ 301
-/QuantMSWeb https://opendda.webapps.openms.org/ 301
-/quantms https://opendda.webapps.openms.org/ 301
-/QuantMS https://opendda.webapps.openms.org/ 301
-/QUANTMS https://opendda.webapps.openms.org/ 301
+/quantms-web http://opendda.webapps.openms.org/ 301
+/quantmsweb http://opendda.webapps.openms.org/ 301
+/QuantMS-Web http://opendda.webapps.openms.org/ 301
+/QuantMSWeb http://opendda.webapps.openms.org/ 301
+/quantms http://opendda.webapps.openms.org/ 301
+/QuantMS http://opendda.webapps.openms.org/ 301
+/QUANTMS http://opendda.webapps.openms.org/ 301
 
-/OpenDIA https://opendia.webapps.openms.org/ 301
-/Opendia https://opendia.webapps.openms.org/ 301
-/opendia https://opendia.webapps.openms.org/ 301
-/OPENDIA https://opendia.webapps.openms.org/ 301
-/open-dia https://opendia.webapps.openms.org/ 301
-/Open-DIA https://opendia.webapps.openms.org/ 301
-/OpenDIAKiosk https://opendia.webapps.openms.org/ 301
-/opendiakiosk https://opendia.webapps.openms.org/ 301
-/OPENDIAKIOSK https://opendia.webapps.openms.org/ 301
+/OpenDIA http://opendia.webapps.openms.org/ 301
+/Opendia http://opendia.webapps.openms.org/ 301
+/opendia http://opendia.webapps.openms.org/ 301
+/OPENDIA http://opendia.webapps.openms.org/ 301
+/open-dia http://opendia.webapps.openms.org/ 301
+/Open-DIA http://opendia.webapps.openms.org/ 301
+/OpenDIAKiosk http://opendia.webapps.openms.org/ 301
+/opendiakiosk http://opendia.webapps.openms.org/ 301
+/OPENDIAKIOSK http://opendia.webapps.openms.org/ 301
 
-/webapps/quantms-web https://opendda.webapps.openms.org/ 301
-/webapps/opendda https://opendda.webapps.openms.org/ 301
-/webapps/opendia https://opendia.webapps.openms.org/ 301
-/webapps/opendiakiosk https://opendia.webapps.openms.org/ 301
+/webapps/quantms-web http://opendda.webapps.openms.org/ 301
+/webapps/opendda http://opendda.webapps.openms.org/ 301
+/webapps/opendia http://opendia.webapps.openms.org/ 301
+/webapps/opendiakiosk http://opendia.webapps.openms.org/ 301
 
 # Redirects for WebApps
 /webapps/* https://abi-services.cs.uni-tuebingen.de/:splat 301
@@ -167,5 +167,5 @@ https://cdash.openms.de/* https://cdash.seqan.de/:splat 301!
 /workshops/quantification https://colab.research.google.com/github/t0mdavid-m/Notebooks-ZA2026/blob/master/Quantification.ipynb
 /workshops/roadshow/fragments http://abi-services.cs.uni-tuebingen.de/toppview-lite/?workspace=workshop
 /workshops/roadshow/umetaflow http://abi-services.cs.uni-tuebingen.de/umetaflow/?workspace=workshop
-/workshops/roadshow/quantms https://opendda.webapps.openms.org/?workspace=workshop
+/workshops/roadshow/quantms http://opendda.webapps.openms.org/?workspace=workshop
 /workshops/upss26 https://colab.research.google.com/github/t0mdavid-m/Notebooks-ZA2026/blob/master/PeptideSearch.ipynb


### PR DESCRIPTION
#### Brief description of what is fixed or changed

This PR adds URL redirects and configuration for two new OpenMS webapps: **OpenDDA** and **OpenDIA**.

**Changes:**

1. **static/_redirects**: Added 30 new redirect rules to handle various URL patterns and case variations for:
   - OpenDDA (6 patterns: `/OpenDDA`, `/opendda`, `/open-dda`, etc.)
   - QuantMS/QuantMS-Web (7 patterns, all redirecting to OpenDDA)
   - OpenDIA (8 patterns: `/OpenDIA`, `/opendia`, `/open-dia`, `/OpenDIAKiosk`, etc.)
   - Webapps subdirectory paths (4 patterns: `/webapps/opendda`, `/webapps/opendia`, etc.)
   - Updated the `/workshops/roadshow/quantms` redirect to point to OpenDDA instead of the old quantms-web service

2. **config.yaml**: Added OpenDIA and OpenDDA to the webapps list in the configuration:
   - OpenDIA (index 2): Interactive web app for teaching and running Data-Independent Acquisition (DIA) analysis
   - OpenDDA (index 3): Browser-based tool for protein identification and quantification from mass spectrometry data
   - Reindexed existing webapps (NUXL, MHCQuant, TOPPView Lite, NASEWEIS, StreamSage) to indices 4-8

These changes enable users to access the new webapps through multiple URL patterns while maintaining backward compatibility with existing redirect rules.

https://claude.ai/code/session_01BbLcphf8EorA3BETrea9Fy