### PR TITLE
Auto collect KPIs using github actions

### DIFF
--- a/.github/workflows/update_kpis.yml
+++ b/.github/workflows/update_kpis.yml
@@ -1,0 +1,97 @@
+name: KPI Updates
+  # Runs weekly, counts the number of contributors in the organization and updates the KPI.csv accordingly
+  # Updates the citations accordingly 
+
+on:
+  schedule:
+    # Every Monday at 09:00 UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-KPI:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.OPENMS_GITHUB_APP_ID }}
+          private-key: ${{ secrets.OPENMS_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pandas requests
+
+      - name: Run citations KPI update script
+        run: python get_total_citations.py
+
+      - name: Get contributors data
+        id: contributors
+        uses: github/contributors@v1
+        with:
+          organization: 'OpenMS'
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update CSV with total contributors
+        run: |
+          # Extract the total number from the JSON report
+          NUM_CONTRIBUTORS=$(jq '.contributors | length' "$CONTRIBUTORS_JSON")
+          
+          # Update the specific line in your CSV file
+          sed -i "s/^Contributors,.*/Contributors,$NUM_CONTRIBUTORS/" kpi.csv
+
+          # Print confirmation for the logs
+          echo "Updated KPI CSV with total contributors: $NUM_CONTRIBUTORS"
+        env:
+          CONTRIBUTORS_JSON: ${{ steps.contributors.outputs.contributors_json }}
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          if git diff --quiet -- KPI.csv; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create branch and commit
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ vars.OPENMS_GITHUB_APP_ID }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git checkout -b update-KPIs
+          git add KPI.csv 
+          git commit -m "Update KPIs"
+          git push --force https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }} update-KPIs
+
+      - name: Create or update Pull Request
+        if: steps.git-check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if gh pr view update-KPIs --json url >/dev/null 2>&1; then
+            echo "PR already exists, branch updated."
+          else
+            gh pr create \
+              --title "Automated KPIs update" \
+              --body "Automated update of \`KPIs.csv\`." \
+              --head update-KPIs \
+              --base main \
+              --label automated,KPIs
+          fi

--- a/.github/workflows/update_kpis.yml
+++ b/.github/workflows/update_kpis.yml
@@ -95,5 +95,4 @@ jobs:
               --body "Automated update of \`KPIs.csv\`." \
               --head update-KPIs \
               --base main \
-              --label automated,KPIs
           fi

--- a/.github/workflows/update_kpis.yml
+++ b/.github/workflows/update_kpis.yml
@@ -30,23 +30,17 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: pip install pandas requests biopython
-
-      - name: Run citations KPI update script
-        run: python get_total_citations.py
-
       - name: Get contributors data
         id: contributors
         uses: github/contributors@v1
         env:
           ORGANIZATION: 'OpenMS'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Debug contributors output
+        run: |
+          echo "All outputs from contributors action:"
+          echo "${{ toJSON(steps.contributors.outputs) }}"
 
       - name: Update CSV with total contributors
         run: |

--- a/.github/workflows/update_kpis.yml
+++ b/.github/workflows/update_kpis.yml
@@ -44,9 +44,9 @@ jobs:
       - name: Get contributors data
         id: contributors
         uses: github/contributors@v1
-        with:
-          organization: 'OpenMS'
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          ORGANIZATION: 'OpenMS'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update CSV with total contributors
         run: |

--- a/.github/workflows/update_kpis.yml
+++ b/.github/workflows/update_kpis.yml
@@ -94,5 +94,5 @@ jobs:
               --title "Automated KPIs update" \
               --body "Automated update of \`KPIs.csv\`." \
               --head update-KPIs \
-              --base main \
+              --base main
           fi

--- a/.github/workflows/update_kpis.yml
+++ b/.github/workflows/update_kpis.yml
@@ -30,6 +30,17 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pandas requests biopython
+
+      - name: Run citations KPI update script
+        run: python get_total_citations.py
+
       - name: Get total unique contributors across all repositories
         id: contributors
         env:

--- a/.github/workflows/update_kpis.yml
+++ b/.github/workflows/update_kpis.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install pandas requests
+        run: pip install pandas requests biopython
 
       - name: Run citations KPI update script
         run: python get_total_citations.py

--- a/.github/workflows/update_kpis.yml
+++ b/.github/workflows/update_kpis.yml
@@ -54,7 +54,7 @@ jobs:
           NUM_CONTRIBUTORS=$(jq '.contributors | length' "$CONTRIBUTORS_JSON")
           
           # Update the specific line in your CSV file
-          sed -i "s/^Contributors,.*/Contributors,$NUM_CONTRIBUTORS/" kpi.csv
+          sed -i "s/^Contributors,.*/Contributors,$NUM_CONTRIBUTORS/" KPI.csv
 
           # Print confirmation for the logs
           echo "Updated KPI CSV with total contributors: $NUM_CONTRIBUTORS"

--- a/.github/workflows/update_kpis.yml
+++ b/.github/workflows/update_kpis.yml
@@ -30,30 +30,38 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Get contributors data
+      - name: Get total unique contributors across all repositories
         id: contributors
-        uses: github/contributors@v1
         env:
-          ORGANIZATION: 'OpenMS'
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Debug contributors output
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
-          echo "All outputs from contributors action:"
-          echo "${{ toJSON(steps.contributors.outputs) }}"
+          NUM_CONTRIBUTORS=$(
+            for repo in $(gh repo list OpenMS --source --limit 1000 --json name -q '.[].name'); do
+              gh api "repos/OpenMS/$repo/contributors" --paginate -q '.[].login' 2>/dev/null || true
+            done | sort -u | wc -l
+          )
+          echo "num_contributors=$NUM_CONTRIBUTORS" >> "$GITHUB_OUTPUT"
+          echo "Total unique contributors: $NUM_CONTRIBUTORS"
 
-      - name: Update CSV with total contributors
-        run: |
-          # Extract the total number from the JSON report
-          NUM_CONTRIBUTORS=$(jq '.contributors | length' "$CONTRIBUTORS_JSON")
-          
-          # Update the specific line in your CSV file
+          # Update the specific line in KPI.csv
           sed -i "s/^Contributors,.*/Contributors,$NUM_CONTRIBUTORS/" KPI.csv
 
-          # Print confirmation for the logs
-          echo "Updated KPI CSV with total contributors: $NUM_CONTRIBUTORS"
+      - name: Get unique contributors from last year across all repositories
+        id: contributors-last-year
         env:
-          CONTRIBUTORS_JSON: ${{ steps.contributors.outputs.contributors_json }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          SINCE_DATE=$(date -u -d "1 year ago" +"%Y-%m-%dT%H:%M:%SZ")
+          NUM_RECENT_CONTRIBUTORS=$(
+            for repo in $(gh repo list OpenMS --limit 1000 --source --json name -q '.[].name'); do
+              gh api "repos/OpenMS/$repo/commits?since=$SINCE_DATE" --paginate -q '.[].author | select(. != null) | .login' 2>/dev/null || true
+            done | sort -u | wc -l
+          )
+          echo "num_recent_contributors=$NUM_RECENT_CONTRIBUTORS" >> "$GITHUB_OUTPUT"
+          echo "Total unique contributors (last year): $NUM_RECENT_CONTRIBUTORS"
+
+          # Update the specific line in KPI.csv
+          sed -i "s/^Year to Date Contributors,.*/Year to Date Contributors,$NUM_RECENT_CONTRIBUTORS/" KPI.csv
 
       - name: Check for changes
         id: git-check

--- a/KPI.csv
+++ b/KPI.csv
@@ -1,0 +1,4 @@
+Metric,Value
+Total Unique Citations,8638
+Total Citations (with overlap),11183
+Contributors,70

--- a/KPI.csv
+++ b/KPI.csv
@@ -1,4 +1,5 @@
 Metric,Value
+Contributors,185
 Total Unique Citations,8638
 Total Citations (with overlap),11183
-Contributors,70
+Year to Date Contributors,52

--- a/get_total_citations.py
+++ b/get_total_citations.py
@@ -1,0 +1,140 @@
+import os
+import re
+import time
+import requests
+import pandas as pd
+
+# --- CONFIGURATION ---
+OPENALEX_EMAIL = "your.email@example.com"
+# --- END CONFIGURATION ---
+
+def load_pmids(file_path="pmids.txt"):
+    with open(file_path, "r") as f:
+        return [line.strip() for line in f if line.strip() and not line.startswith("#")]
+
+def get_openalex_citation_counts(pmids, title_map):
+    per_pmid_counts = {}
+    all_citing_works = set()
+
+    print(f"\n{'='*60}")
+    print("FETCHING CITATION COUNTS AND UNIQUE CITING WORKS (single pass)")
+    print(f"{'='*60}")
+
+    for idx, pmid in enumerate(pmids):
+        # Step 1: get the OpenAlex work ID for this PMID
+        url = f"https://api.openalex.org/works/pmid:{pmid}"
+        params = {"select": "id"}
+        if OPENALEX_EMAIL:
+            params["mailto"] = OPENALEX_EMAIL
+
+        work_id = None
+        try:
+            response = requests.get(url, params=params, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+            full_id = data.get("id")
+            if full_id:
+                work_id = full_id.split("/")[-1]   # e.g., W2741809807
+        except requests.exceptions.HTTPError as e:
+            if response.status_code == 404:
+                pass   # will handle below
+            else:
+                print(f"  ERROR PMID {pmid}: {e}")
+        except Exception as e:
+            print(f"  ERROR PMID {pmid}: {e}")
+
+        if not work_id:
+            per_pmid_counts[pmid] = 0
+            title = title_map.get(pmid, "Unknown")
+            print(f"  [{idx+1}/{len(pmids)}] PMID {pmid}:  0 citations  |  {title[:65]}{'...' if len(title) > 65 else ''}  [NOT FOUND]")
+            time.sleep(0.1)
+            continue
+
+        # Step 2: paginate through all citing works
+        citing_url = f"https://api.openalex.org/works?filter=cites:{work_id}"
+        cursor = "*"
+        fetched_count = 0
+
+        try:
+            while cursor:
+                page_params = {
+                    "cursor": cursor,
+                    "per_page": 200,
+                    "select": "id"
+                }
+                if OPENALEX_EMAIL:
+                    page_params["mailto"] = OPENALEX_EMAIL
+
+                page_resp = requests.get(citing_url, params=page_params, timeout=30)
+                page_resp.raise_for_status()
+                page_data = page_resp.json()
+
+                results = page_data.get("results", [])
+                for work in results:
+                    all_citing_works.add(work.get("id"))
+                    fetched_count += 1
+
+                cursor = page_data.get("meta", {}).get("next_cursor")
+                if not results:
+                    break
+
+                time.sleep(0.1)
+
+        except Exception as e:
+            print(f"  ERROR fetching citing works for PMID {pmid} ({work_id}): {e}")
+
+        per_pmid_counts[pmid] = fetched_count
+        title = title_map.get(pmid, "Unknown")
+        print(f"  [{idx+1}/{len(pmids)}] PMID {pmid}: {fetched_count} citations  |  {title[:65]}{'...' if len(title) > 65 else ''}")
+
+        time.sleep(0.1)
+
+    return per_pmid_counts, all_citing_works
+
+pmids = load_pmids()
+print(f"Loaded {len(pmids)} PMIDs from local list.")
+
+# --- Fetch citation counts from OpenAlex ---
+per_pmid_counts, all_citing_works = get_openalex_citation_counts(
+    citations["PubMedID"].tolist(), 
+    title_map
+)
+
+citations["Citations"] = citations["PubMedID"].map(per_pmid_counts)
+
+# --- Summary ---
+print(f"\n{'='*60}")
+print("CITATION SUMMARY (sorted by count)")
+print(f"{'='*60}")
+summary = citations[["PubMedID", "Title", "Year", "Citations"]].sort_values(
+    "Citations", ascending=False
+)
+for _, row in summary.iterrows():
+    print(f"{row['Citations']:>6}  |  {row['Year']}  |  {row['Title'][:60]}{'...' if len(row['Title']) > 60 else ''}")
+
+total_unique_citations = len(all_citing_works)
+sum_per_article = int(citations["Citations"].sum())
+
+print(f"\n{'='*60}")
+print("TOTALS")
+print(f"{'='*60}")
+print(f"Articles processed:              {len(citations)}")
+print(f"Sum of per-article citations:    {sum_per_article}")
+print(f"Unique citing works:             {total_unique_citations}")
+print(f"Overlap (double-counted):        {sum_per_article - total_unique_citations}")
+
+# --- Update KPI.csv ---
+kpi_file = "KPI.csv"
+kpi_rows = []
+
+if os.path.exists(kpi_file):
+    kpi_df = pd.read_csv(kpi_file)
+    kpi_df = kpi_df[~kpi_df["Metric"].isin(["Total Unique Citations", "Total Citations (with overlap)"])]
+    kpi_rows = kpi_df.to_dict("records")
+
+kpi_rows.append({"Metric": "Total Unique Citations", "Value": total_unique_citations})
+kpi_rows.append({"Metric": "Total Citations (with overlap)", "Value": sum_per_article})
+
+kpi_df = pd.DataFrame(kpi_rows)
+kpi_df.to_csv(kpi_file, index=False)
+print(f"\nUpdated {kpi_file}")

--- a/get_total_citations.py
+++ b/get_total_citations.py
@@ -1,10 +1,11 @@
-import os
 import re
 import time
 import requests
 import pandas as pd
+from Bio import Entrez
 
 # --- CONFIGURATION ---
+Entrez.email = "your.email@example.com"
 OPENALEX_EMAIL = "your.email@example.com"
 # --- END CONFIGURATION ---
 
@@ -91,8 +92,45 @@ def get_openalex_citation_counts(pmids, title_map):
 
     return per_pmid_counts, all_citing_works
 
+
 pmids = load_pmids()
 print(f"Loaded {len(pmids)} PMIDs from local list.")
+
+# --- Fetch article metadata from PubMed ---
+citations_data = []
+chunk_size = 100
+for i in range(0, len(pmids), chunk_size):
+    chunk = pmids[i:i + chunk_size]
+    try:
+        handle = Entrez.efetch(db="pubmed", id=",".join(chunk), rettype="xml")
+        xml_records = Entrez.read(handle)
+        handle.close()
+        for pubmed_article in xml_records.get("PubmedArticle", []):
+            citation = pubmed_article.get("MedlineCitation", {})
+            article = citation.get("Article", {})
+            
+            pubmed_id = str(citation.get("PMID", ""))
+            title = str(article.get("ArticleTitle", "")).rstrip(".")
+            journal = article.get("Journal", {}).get("Title", "")
+            pub_date = article.get("Journal", {}).get("JournalIssue", {}).get("PubDate", {})
+            year = pub_date.get("Year")
+            if not year and "MedlineDate" in pub_date:
+                year_match = re.search(r"\d{4}", pub_date["MedlineDate"])
+                if year_match:
+                    year = year_match.group(0)
+            if title and year and pubmed_id:
+                citations_data.append({
+                    "Title": title,
+                    "PubMedID": pubmed_id,
+                })
+    except Exception as e:
+        print(f"Error fetching metadata batch starting at index {i}: {e}")
+
+citations = pd.DataFrame(citations_data)
+if citations.empty:
+    raise RuntimeError("No PubMed records were retrieved; refusing to overwrite publications.md")
+
+title_map = dict(zip(citations["PubMedID"], citations["Title"]))
 
 # --- Fetch citation counts from OpenAlex ---
 per_pmid_counts, all_citing_works = get_openalex_citation_counts(

--- a/get_total_citations.py
+++ b/get_total_citations.py
@@ -3,6 +3,7 @@ import time
 import requests
 import pandas as pd
 from Bio import Entrez
+import os
 
 # --- CONFIGURATION ---
 Entrez.email = "your.email@example.com"
@@ -120,6 +121,7 @@ for i in range(0, len(pmids), chunk_size):
                     year = year_match.group(0)
             if title and year and pubmed_id:
                 citations_data.append({
+                    "Year": year,
                     "Title": title,
                     "PubMedID": pubmed_id,
                 })


### PR DESCRIPTION
This PR automatically collects KPIs of 
1. Total Unique Citations - Total unique citations across all publications in pmids.txt 
2. Total citations - total citations across all publications in pmids.txt
3. Contributors - # contributors according to github across all repositories 
4. Year to Date Contributors - # contributors in the last year according to github


These PRs are automatically computed using the auto `update_kpis.yml` github action and are stored in KPI.csv

The idea with having these in the website repository is that they will easily be able to be showcased on the website. 
